### PR TITLE
Add version property to ViewerOptions

### DIFF
--- a/projects/ng2-adsk-forge-viewer/src/lib/component/viewer.component.ts
+++ b/projects/ng2-adsk-forge-viewer/src/lib/component/viewer.component.ts
@@ -47,6 +47,7 @@ export interface ViewerOptions {
   enableMemoryManagement?: boolean;
   onViewerScriptsLoaded?: () => void;
   onViewerInitialized: (args: ViewerInitializedEvent) => void;
+  version?: string | number;
 }
 
 
@@ -196,8 +197,10 @@ export class ViewerComponent implements OnDestroy {
    * to add the scripts to their index.html pages. So we'll load them when required.
    */
   private loadScripts(): Promise<void> {
+    const version = this.viewerOptions.version || '7.*';
+    const url = `https://developer.api.autodesk.com/modelderivative/v2/viewers/${version}/viewer3D.min.js`
     return this.script.load(
-      'https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/viewer3D.min.js',
+      url,
     )
       .then((data) => {
         this.log('script loaded ', data);

--- a/projects/ng2-adsk-forge-viewer/src/lib/component/viewer.component.ts
+++ b/projects/ng2-adsk-forge-viewer/src/lib/component/viewer.component.ts
@@ -198,7 +198,7 @@ export class ViewerComponent implements OnDestroy {
    */
   private loadScripts(): Promise<void> {
     const version = this.viewerOptions.version || '7.*';
-    const url = `https://developer.api.autodesk.com/modelderivative/v2/viewers/${version}/viewer3D.min.js`
+    const url = `https://developer.api.autodesk.com/modelderivative/v2/viewers/${version}/viewer3D.min.js`;
     return this.script.load(
       url,
     )


### PR DESCRIPTION
Added version parameter for the viewer3D.min.js file. It's currently set to 7.* which grabs the most current version. 
Reason: We encountered a problem with a new version and the code didn't work anymore due to some changes we couldn't identify. Passing fixed version instead of the wildcard did the job. 