### PR TITLE
Enable loading local SVF files

### DIFF
--- a/projects/ng2-adsk-forge-viewer/src/lib/component/viewer.component.ts
+++ b/projects/ng2-adsk-forge-viewer/src/lib/component/viewer.component.ts
@@ -248,8 +248,13 @@ export class ViewerComponent implements OnDestroy {
       this.viewer = new Autodesk.Viewing.GuiViewer3D(this.Container, config);
     }
 
+    // set a document url if environment set to Local
+    let url: string;
+    if (this.viewerOptions.initializerOptions.env === 'Local') {
+      url = this.viewerOptions.initializerOptions.document;
+    }
     // Start the viewer
-    this.viewer.start(undefined);
+    this.viewer.start(url);
 
     // Viewer is ready - scripts are loaded and we've create a new viewing application
     this.viewerInitialized = true;


### PR DESCRIPTION
If `initializerOptions.env` is equal to `Local` it starts the viewer and loads an SVF file via http circumventing the Model Derivatives API. The SVF file url is specified in initializerOptions as `document`. 
Used `initalizerOptions.document` as it matches types and the example from Autodesk guys: https://github.com/Autodesk-Forge/viewer-javascript-offline.sample/blob/gh-pages/index.html
